### PR TITLE
Consistent tabs and spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,19 +11,19 @@
         "url": "https://github.com/mastazi/VS-code-vagrantfile.git"
     },
     "license": "SEE LICENSE IN LICENSE.txt",
-	"icon": "images/icon.png",
+    "icon": "images/icon.png",
     "categories": [
         "Other"
     ],
     "publisher": "marcostazi",
     "contributes": {
         "languages": [{
-			"id": "ruby",
-			"filenames": [
-				"Vagrantfile",
-				".vagrantuser",
+            "id": "ruby",
+            "filenames": [
+                "Vagrantfile",
+                ".vagrantuser",
                 "Vagrantfile.local"
-			]
-		}]
+            ]
+        }]
     }
 }


### PR DESCRIPTION
Hi @mastazi. In this PR, I've changed all tabs to 4 spaces. Github uses 8 spaces to display tabs and it messes up the indentation